### PR TITLE
Simplified Offset Processing

### DIFF
--- a/Tests/SwiftLintFrameworkTests/TestHelpers.swift
+++ b/Tests/SwiftLintFrameworkTests/TestHelpers.swift
@@ -58,10 +58,9 @@ private func render(locations: [Location], in contents: String) -> String {
     var contents = contents.bridge().lines().map { $0.content }
     for location in locations.sorted(by: > ) {
         guard let line = location.line, let character = location.character else { continue }
-        var content = contents[line - 1]
-        let index = content.index(content.startIndex, offsetBy: character - 1)
-        content.insert("↓", at: index)
-        contents[line - 1] = content
+        let content = NSMutableString(string: contents[line - 1])
+        content.insert("↓", at: character - 1)
+        contents[line - 1] = content as String
     }
     return (["```"] + contents + ["```"]).joined(separator: "\n")
 }

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -53,14 +53,16 @@ class TrailingCommaRuleTests: XCTestCase {
                 "let foo = [1: 2,\n 2: 3↓]\n",
                 "let foo = [1: 2,\n 2: 3↓   ]\n",
                 "struct Bar {\n let foo = [1: 2,\n 2: 3↓]\n}\n",
-                "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n"
+                "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n",
+                "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\"↓]\n"
             ],
             corrections: [
                 "let foo = [1, 2,\n 3↓]\n": "let foo = [1, 2,\n 3,]\n",
                 "let foo = [1: 2,\n 2: 3↓]\n": "let foo = [1: 2,\n 2: 3,]\n",
                 "let foo = [1: 2,\n 2: 3↓   ]\n": "let foo = [1: 2,\n 2: 3,   ]\n",
                 "struct Bar {\n let foo = [1: 2,\n 2: 3↓]\n}\n": "struct Bar {\n let foo = [1: 2,\n 2: 3,]\n}\n",
-                "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n": "let foo = [1, 2,\n 3,] + [4,\n 5, 6,]\n"
+                "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n": "let foo = [1, 2,\n 3,] + [4,\n 5, 6,]\n",
+                "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\"↓]\n": "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\",]\n"
             ]
 
         )

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -26,46 +26,47 @@ class TrailingCommaRuleTests: XCTestCase {
         )
     }
 
+    private let mandatoryCommaRuleDescription = RuleDescription(
+        identifier: TrailingCommaRule.description.identifier,
+        name: TrailingCommaRule.description.name,
+        description: TrailingCommaRule.description.description,
+        nonTriggeringExamples: [
+            "let foo = []\n",
+            "let foo = [:]\n",
+            "let foo = [1, 2, 3,]\n",
+            "let foo = [1, 2, 3, ]\n",
+            "let foo = [1, 2, 3   ,]\n",
+            "let foo = [1: 2, 2: 3, ]\n",
+            "struct Bar {\n let foo = [1: 2, 2: 3,]\n}\n",
+            "let foo = [Void]()\n",
+            "let foo = [(Void, Void)]()\n",
+            "let foo = [1, 2, 3]\n",
+            "let foo = [1: 2, 2: 3]\n",
+            "let foo = [1: 2, 2: 3   ]\n",
+            "struct Bar {\n let foo = [1: 2, 2: 3]\n}\n",
+            "let foo = [1, 2, 3] + [4, 5, 6]\n"
+        ],
+        triggeringExamples: [
+            "let foo = [1, 2,\n 3↓]\n",
+            "let foo = [1: 2,\n 2: 3↓]\n",
+            "let foo = [1: 2,\n 2: 3↓   ]\n",
+            "struct Bar {\n let foo = [1: 2,\n 2: 3↓]\n}\n",
+            "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n",
+            "let foo = [\"אבג\", \"αβγ\",\n\"🇺🇸\"↓]\n"
+        ],
+        corrections: [
+            "let foo = [1, 2,\n 3↓]\n": "let foo = [1, 2,\n 3,]\n",
+            "let foo = [1: 2,\n 2: 3↓]\n": "let foo = [1: 2,\n 2: 3,]\n",
+            "let foo = [1: 2,\n 2: 3↓   ]\n": "let foo = [1: 2,\n 2: 3,   ]\n",
+            "struct Bar {\n let foo = [1: 2,\n 2: 3↓]\n}\n": "struct Bar {\n let foo = [1: 2,\n 2: 3,]\n}\n",
+            "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n": "let foo = [1, 2,\n 3,] + [4,\n 5, 6,]\n",
+            "let foo = [\"אבג\", \"αβγ\",\n\"🇺🇸\"↓]\n": "let foo = [\"אבג\", \"αβγ\",\n\"🇺🇸\",]\n"
+        ]
+    )
+
     func testTrailingCommaRuleWithMandatoryComma() {
         // Verify TrailingCommaRule with test values for when mandatory_comma is true.
-        let ruleDescription = RuleDescription(
-            identifier: TrailingCommaRule.description.identifier,
-            name: TrailingCommaRule.description.name,
-            description: TrailingCommaRule.description.description,
-            nonTriggeringExamples: [
-                "let foo = []\n",
-                "let foo = [:]\n",
-                "let foo = [1, 2, 3,]\n",
-                "let foo = [1, 2, 3, ]\n",
-                "let foo = [1, 2, 3   ,]\n",
-                "let foo = [1: 2, 2: 3, ]\n",
-                "struct Bar {\n let foo = [1: 2, 2: 3,]\n}\n",
-                "let foo = [Void]()\n",
-                "let foo = [(Void, Void)]()\n",
-                "let foo = [1, 2, 3]\n",
-                "let foo = [1: 2, 2: 3]\n",
-                "let foo = [1: 2, 2: 3   ]\n",
-                "struct Bar {\n let foo = [1: 2, 2: 3]\n}\n",
-                "let foo = [1, 2, 3] + [4, 5, 6]\n"
-            ],
-            triggeringExamples: [
-                "let foo = [1, 2,\n 3↓]\n",
-                "let foo = [1: 2,\n 2: 3↓]\n",
-                "let foo = [1: 2,\n 2: 3↓   ]\n",
-                "struct Bar {\n let foo = [1: 2,\n 2: 3↓]\n}\n",
-                "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n",
-                "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\"↓]\n"
-            ],
-            corrections: [
-                "let foo = [1, 2,\n 3↓]\n": "let foo = [1, 2,\n 3,]\n",
-                "let foo = [1: 2,\n 2: 3↓]\n": "let foo = [1: 2,\n 2: 3,]\n",
-                "let foo = [1: 2,\n 2: 3↓   ]\n": "let foo = [1: 2,\n 2: 3,   ]\n",
-                "struct Bar {\n let foo = [1: 2,\n 2: 3↓]\n}\n": "struct Bar {\n let foo = [1: 2,\n 2: 3,]\n}\n",
-                "let foo = [1, 2,\n 3↓] + [4,\n 5, 6↓]\n": "let foo = [1, 2,\n 3,] + [4,\n 5, 6,]\n",
-                "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\"↓]\n": "let foo = [\"אבג\", \"αβγ\", \"🇺🇸\",]\n"
-            ]
-
-        )
+        let ruleDescription = mandatoryCommaRuleDescription
         let ruleConfiguration = ["mandatory_comma": true]
 
         verifyRule(ruleDescription, ruleConfiguration: ruleConfiguration)


### PR DESCRIPTION
1. The first commit is the only one that deals with your code. It does two things:

- Adds the test with special characters to the other test sets (mandatory comma option, etc.)
- Simplifies offset processing. (Look at the diffs to understand what I did.)

2. The second commit was needed to fix a latent bug in the test infrastructure, because the test reporter was using UTF‐16 offsets as if they were grapheme cluster offsets. It was just waiting for someone to put emoticons near the end of a string in order to crash, and I guess we were the first to do so.

3. The third commit was to satisfy the function length limit imposed by SwiftLint.